### PR TITLE
Remove regeneration of token after validation

### DIFF
--- a/src/CSRF.php
+++ b/src/CSRF.php
@@ -69,12 +69,7 @@ class CSRF {
 		} elseif (empty($request_data[$token_name])) {
 			return false;
 		} else {
-			if(static::compare($request_data[$token_name], static::getToken($token_name))){
-				static::generateToken($token_name);
-				return true;
-			} else {
-				return false;
-			}
+			return static::compare($request_data[$token_name], static::getToken($token_name));
 		}
 	}
 


### PR DESCRIPTION
Generating a new token after a validation break the possibility to use multiple tabs for same form.
See #5 